### PR TITLE
Small changes. Refactored verb loop. i not needed

### DIFF
--- a/fortune_cookie.py
+++ b/fortune_cookie.py
@@ -41,7 +41,7 @@ def noun_replace(original_document):
     
     return noun_mod_docs
 
-def verb_replace(original_document, i=0):
+def verb_replace(original_document):
     '''Returns a document replacing verbs meeting specified criteria with the
     structure "will {lemmatized verb}"
     
@@ -49,23 +49,25 @@ def verb_replace(original_document, i=0):
     ----------
     original_document : str
         Document in which you would like to replace verbs
-
-    i : int
-        Counter set to 0. I should put it in the function instead. I'll do that
-        later because right now it's working, and changing that will probably
-        magically break it... haha (sort of)
-
     '''
+
+    # Note: The docstring above is edited out as the idx i is no longer needed
+    # see the code changes below in the for loop. 
+
     nlp_doc = nlp(original_document)
 
     verb_count = 0
     for token in nlp_doc:
         if token.pos_ in ['VERB', 'AUX']:
-            verb_count +=1
+            verb_count += 1
+
     # print("vc:",verb_count)
     # print("i:",i)
 
-    if i == verb_count:
+    # if i == verb_count:
+    #     return original_document
+
+    if verb_count == 0:
         return original_document
     
     for token in nlp_doc:
@@ -73,17 +75,38 @@ def verb_replace(original_document, i=0):
         # print(spacy.explain(token.tag_), '\n')
         token_tag = spacy.explain(token.tag_)
 
-        if (token.pos_ in ['VERB', 'AUX']
-            and token_tag in ["verb, 3rd person singular present"
-                             ,"verb, non-3rd person singular present"]
-            and token.dep_ != 'advcl'):
-            # This will not work for adverbial clauses, so add that logic in later
-            working_doc = original_document.replace(str(token),f"will {token.lemma_}")
-            # print("Working Doc:",working_doc)
-            i+=1
-            return verb_replace(working_doc, i)
+        # Creating bail out statements (fail conditions) 
+        # to simplify the if section of the original code
+        # so as to be more readable (to me at least)
 
-    return original_document
+        # If the token in question isn't a verb or auxiliary verb
+        # continue on to the next token in the document
+        if token.pos_ not in ['VERB', 'AUX']:
+            continue
+        
+        # If the token tag isn't a 3rd person singular present tense verb
+        # or non-3rd person singular present tense verb, continue onward.
+        if token_tag not in ["verb, 3rd person singular present"
+                             , "verb, non-3rd person singular present"]:
+            continue
+
+        # If the token dependency is an adverbial clause, we want to bail 
+        # out early for now as this will not work for adverbial clauses; 
+        # logic will be added in later
+        if token.dep_ == 'advcl':
+            continue
+
+        # Now that the fail conditions are checked, 
+        # we can directly use the original logic.
+        # This logic will loop through the tokens in order
+        # meaning we no longer need to increment i. 
+        # The code for i is commented out below. 
+        working_doc = original_document.replace(str(token),
+                                                f"will {token.lemma_}")
+        # print("Working Doc:",working_doc)
+        # i+=1
+        # return verb_replace(working_doc, i)
+        return working_doc
 
 
 # nlp = spacy.load('en_core_web_sm')

--- a/test_cases.py
+++ b/test_cases.py
@@ -1,0 +1,37 @@
+# This is to store some of the example sentences at the bottom of 
+# the fortune_cookie.py file and create a type of test structure
+# to see if the functions produce the correct output.
+
+EXAMPLE_SENTENCES = [
+'An RAF squadron is assigned to knock out a German rocket fuel factory in Norway.'
+, 'A meek Hobbit from the Shire and eight companions set out on a journey to destroy the powerful One Ring and save Middle-earth from the Dark Lord Sauron.'
+, 'The ninja find themselves trapped in a pyramid and must escape encroaching lava to warn Ninjago City of a new Serpentine invasion.'
+, 'When the menace known as the Joker wreaks havoc and chaos on the people of Gotham, Batman must accept one of the greatest psychological and physical tests of his ability to fight injustice.'
+, 'Two imprisoned men bond over a number of years, finding solace and eventual redemption through acts of common decency.'
+, "A cowboy doll is profoundly threatened and jealous when a new spaceman action figure supplants him as top toy in a boy's bedroom."
+, 'A man raised by gorillas must decide where he really belongs when he discovers he is a human.'
+, "To save her father from death in the army, a young maiden secretly goes in his place and becomes one of China's greatest heroines in the process."
+, 'An English soldier and the daughter of an Algonquin chief share a romance when English colonists invade seventeenth century Virginia.'
+, "A poor but hopeful boy seeks one of the five coveted golden tickets that will send him on a tour of Willy Wonka's mysterious chocolate factory."
+]
+
+EXPECTED_OUTPUT = [
+"You will be assigned to knock out a German rocket fuel factory in Norway."
+, "You from the Shire and eight companions will set out on a journey to destroy the powerful One Ring and save Middle-earth from the Dark Lord Sauron."
+, "You will find yourself trapped in a pyramid and must escape encroaching lava to warn Ninjago City of a new Serpentine invasion."
+, "When you known as the Joker will wreak havoc and chaos on the people of Gotham, Batman will accept one of the greatest psychological and physical tests of his ability to fight injustice."
+, "You will bond over a number of years, finding solace and eventual redemption through acts of common decency."
+, "You will be profoundly threatened and jealous when a new spaceman action figure supplants him as top"
+
+# The following output is a tricky case as the model verb 'must' 
+# effectively shows "future" via a currently unfulfilled obligation.  
+# The model will likely mislabel or decide that "must decide" will become
+# "must will decide" which is incorrect
+, "You raised by gorillas must decide where you really will belong when you discover you are a human."
+, "To save your father from death in the army, you secretly will go in his place and become one of China's greatest heroines in the process."
+, "You will share a romance when English colonists invade seventeenth century Virginia."
+
+# This one is also slightly awkward to convert to "you" + future tense.
+# The following removes the clause that modifies the original NP
+, "You will seek one of the five coveted golden tickets that will send you on a tour of Willy Wonka's mysterious chocolate factory."
+]


### PR DESCRIPTION
Pretty small changes.  I was able to look at the code and step through how the verb replacement was happening.  The index i is factored out of the code as a result and recursion doesn't need to happen.  Also added in a file called test_cases.py which contains the sentences that you had commented out at the bottom of the fortune_cookie.py file.

I wanted to see if I could take a crack at the adverbial phrase detection; however, still have to do my research responsibilities.  Hope the changes are helpful Eric! 