### PR TITLE
Format and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,19 @@ You've probably wondered that many times. Or maybe you haven't - that's fine too
 This repo is a project currently in progress to create some sort of application using spaCy to transform brief movie synopses into fortune cookie statements and, hopefully, a web app that will be fun to use.
 
 Thanks for visiting!
+
+## Running the web app
+Make sure you're in `fcm_dashApp/` and run `python fcm_app.py`
+
+#### Possible errors
+```
+subprocess.CalledProcessError: Command '['/usr/bin/java', '-version']' returned non-zero exit status 1.
+```
+- If you're on MacOS, make sure you have a Java installed.
+
+```
+OSError: [E050] Can't find model 'en_core_web_trf'. It doesn't seem to be a Python package or a valid path to a data directory.
+```
+- `python -m spacy download en_core_web_trf`  
+or
+- `python3 -m spacy download en_core_web_trf`

--- a/fcm_dashApp/fcm_code/dataset_builder.py
+++ b/fcm_dashApp/fcm_code/dataset_builder.py
@@ -1,7 +1,12 @@
 import requests
 from config import api_key
-from os.path import exists
 import pickle
+import os
+
+
+MOVIE_DATA_PATH = os.path.join(".", "data", "movie_data.p")
+MOVIE_ID_PATH = os.path.join(".", "data", "movie_ids.p")
+
 
 class MovieDict:
     """
@@ -10,11 +15,11 @@ class MovieDict:
     def __init__(self):
         """
         """
-        movie_dict_exists = exists("..\\data\\movie_data.p")
+        movie_dict_exists = os.path.exists(MOVIE_DATA_PATH)
         if movie_dict_exists == True:
-            with open("..\\data\\movie_data.p", 'rb') as p:
+            with open(MOVIE_DATA_PATH, 'rb') as p:
                 self.movie_data = pickle.load(p)
-            with open("..\\data\\movie_ids.p", 'rb') as p:
+            with open(MOVIE_ID_PATH, 'rb') as p:
                 self.movie_ids = pickle.load(p)
         else:
             self.movie_data = {}
@@ -67,13 +72,15 @@ class MovieDict:
                     break
 
     def save_movie_data(self, filename='movie_data', filetype='p'):
-        with open(f"..\\data\\{filename}.{filetype}", "wb") as p:
+        filepath = os.path.join("..", "data", f"{filename}.{filetype}")
+        with open(filepath, "wb") as p:
             pickle.dump(self.movie_data, p)
         print("movie data saved")
 
     
     def save_movie_ids(self, filename='movie_ids', filetype='p'):
-        with open(f"..\\data\\{filename}.{filetype}", "wb") as p:
+        filepath = os.path.join("..", "data", f"{filename}.{filetype}")
+        with open(filepath, "wb") as p:
             pickle.dump(self.movie_ids, p)
             print("movie ids saved")
 
@@ -81,7 +88,7 @@ class MovieDict:
 
 movies = MovieDict()
 
-for i in range(0,10):  # Currently duplicating API calls, keep this under 10
+for i in range(10):  # Currently duplicating API calls, keep this under 10
     movies.get_movies()
     i+=1
 

--- a/fcm_dashApp/fcm_code/fortune_cookie.py
+++ b/fcm_dashApp/fcm_code/fortune_cookie.py
@@ -219,9 +219,7 @@ def capitalize_first_letter(text):
 
     matches = [rule for rule in matches if cap_rule(rule)]
 
-    new_text = language_tool_python.utils.correct(text, matches)
-    
-    return new_text
+    return language_tool_python.utils.correct(text, matches)
 
 
 if __name__ == "__main__":

--- a/fcm_dashApp/fcm_code/fortune_cookie.py
+++ b/fcm_dashApp/fcm_code/fortune_cookie.py
@@ -51,7 +51,7 @@ def count_pronoun_types(original_document):
     return len(unique_pronoun_types_present)
 
 def pronoun_replace(original_document, i=0):
-    '''Replace a single family of pronouns with second-person pronouns.
+    """Replace a single family of pronouns with second-person pronouns.
 
     Note: This function currently only replaces pronouns in sentences containing
         a single family of pronouns, such as feminine singular (she/her) or
@@ -63,7 +63,7 @@ def pronoun_replace(original_document, i=0):
     original_document : str
         Document that needs pronouns replaced.
     
-    '''
+    """
 
     nlp_doc = nlp(original_document)
 
@@ -96,7 +96,7 @@ def pronoun_replace(original_document, i=0):
 
 
 def noun_replace(original_document):
-    '''Returns a list of documents. Noun chunks that meet the specified
+    """Returns a list of documents. Noun chunks that meet the specified
     dependency and POS criteria are replaced with 'you'.
     
     Parameters
@@ -110,7 +110,7 @@ def noun_replace(original_document):
     Returns:    ['you will cry when Alice takes the ball away.',
                 'Bobby will cry when you takes the ball away.']
 
-    '''
+    """
 
     labels = ["nsubj", "nsubjpass", "attr", "ROOT",
         # "pcomp","pobj","dative","appos","dobj",
@@ -129,7 +129,7 @@ def noun_replace(original_document):
     return noun_mod_docs
 
 def verb_replace(original_document, i=0):
-    '''Returns a document replacing verbs meeting specified criteria with the
+    """Returns a document replacing verbs meeting specified criteria with the
     structure "will {lemmatized verb}"
     
     Parameters
@@ -140,7 +140,7 @@ def verb_replace(original_document, i=0):
         Counter set to 0. I should put it in the function instead. I'll do that
         later because right now it's working, and changing that will probably
         magically break it... haha (sort of)
-    '''
+    """
     nlp_doc = nlp(original_document)
 
     verb_count = 0

--- a/fcm_dashApp/fcm_code/fortune_cookie.py
+++ b/fcm_dashApp/fcm_code/fortune_cookie.py
@@ -6,12 +6,17 @@ from spacy.matcher import Matcher
 import textacy
 from textacy import extract
 import language_tool_python
-from fcm_code import test_cases
+import pickle
+# from fcm_code import test_cases
+
+# Import the data
+with open("..\\data\\movie_data.p", 'rb') as p:
+    movie_data = pickle.load(p)
 
 tool = language_tool_python.LanguageTool('en-US')
 
-nlp = spacy.load('en_core_web_sm')    # small spaCy English language model
-# nlp = spacy.load('en_core_web_trf')     # large spaCy English language model
+# nlp = spacy.load('en_core_web_sm')    # small spaCy English language model
+nlp = spacy.load('en_core_web_trf')     # large spaCy English language model
 
 #families of related pronouns:
 pronouns_dict = {"third_male":["he", "him", "his", "himself"]
@@ -219,7 +224,9 @@ if __name__ == "__main__":
 
     all_outputs = []
 
-    for plot in test_cases.EXAMPLE_SENTENCES:
+    for k in movie_data:
+        plot = movie_data[k]['plot']
+    # for plot in test_cases.EXAMPLE_SENTENCES:
         pronouns_replaced = pronoun_replace(plot)
         nouns_replaced = noun_replace(pronouns_replaced)
 

--- a/fcm_dashApp/fcm_code/fortune_cookie.py
+++ b/fcm_dashApp/fcm_code/fortune_cookie.py
@@ -8,10 +8,15 @@ from textacy import extract
 import language_tool_python
 import pickle
 import re
+import os
 # from fcm_code import test_cases
 
+
+MOVIE_DATA_PATH = os.path.join(".", "data", "movie_data.p")
+
+
 # Import the data
-with open("..\\data\\movie_data.p", 'rb') as p:
+with open(MOVIE_DATA_PATH, 'rb') as p:
     movie_data = pickle.load(p)
 
 tool = language_tool_python.LanguageTool('en-US')

--- a/fcm_dashApp/fcm_code/fortune_cookie.py
+++ b/fcm_dashApp/fcm_code/fortune_cookie.py
@@ -7,6 +7,7 @@ import textacy
 from textacy import extract
 import language_tool_python
 import pickle
+import re
 # from fcm_code import test_cases
 
 # Import the data
@@ -25,7 +26,31 @@ pronouns_dict = {"third_male":["he", "him", "his", "himself"]
                                 ,"themselves"]}
 
 
-def pronoun_replace(original_document):
+
+def count_pronoun_types(original_document):
+    nlp_doc = nlp(original_document)
+
+    ######################
+    # First chunk is seeing how many different types of pronouns are present
+    pronoun_types_present = []
+
+    for token in nlp(nlp_doc):
+        if token.pos_ == "PRON":
+            # print(token)
+            for key, val in pronouns_dict.items():
+                # print(key)
+                # print(val)
+                if str(token) in val:
+                    pronoun_types_present.append(key)
+
+    unique_pronoun_types_present = set(pronoun_types_present)
+
+    # if len(unique_pronoun_types_present)>1:
+    #     return original_document
+
+    return len(unique_pronoun_types_present)
+
+def pronoun_replace(original_document, i=0):
     '''Replace a single family of pronouns with second-person pronouns.
 
     Note: This function currently only replaces pronouns in sentences containing
@@ -42,38 +67,33 @@ def pronoun_replace(original_document):
 
     nlp_doc = nlp(original_document)
 
-    pronoun_types_present = []
+    pronoun_count = 0
+    for token in nlp_doc:
+        if spacy.explain(token.tag_) in ["pronoun, possessive", "pronoun, personal"]:
+            pronoun_count +=1
 
-    for token in nlp(nlp_doc):
-        if token.pos_ == "PRON":
-            # print(token)
-            for key, val in pronouns_dict.items():
-                # print(key)
-                # print(val)
-                if str(token) in val:
-                    pronoun_types_present.append(key)
-
-    if len(pronoun_types_present)>1:
+    if i == pronoun_count:
         return original_document
 
-    # use loop to replace diff types of pronouns, similar to verb_replace
-    working_doc = ""
+    # Loop replaces diff types of pronouns, similar to verb_replace
     for token in nlp_doc:
         token_tag = spacy.explain(token.tag_)
 
-        if token_tag == "pronoun, possessive":
-            working_doc = original_document.replace(str(token), "your")
+        if (token_tag == "pronoun, possessive"
+            and str(token) != "your"):
+            working_doc = re.sub(r'\b' + str(token) + r'\b', "your", original_document)
+            i+=1
+            return pronoun_replace(working_doc, i)
         
-        # this may overwrite "you", so I'd need to put it before the
-        # noun_replace function
-        if token_tag == "pronoun, personal":
-            working_doc = original_document.replace(str(token), "yourself")
-                
-    # Only return if replacements have been made
-    if len(working_doc) > 0:
-        return working_doc
+        if (token_tag == "pronoun, personal"
+            and str(token) != "yourself"):
+            # working_doc = original_document.replace(str(token), "yourself")
+            working_doc = re.sub(r'\b' + str(token) + r'\b', "you", original_document)
+            i+=1
+            return pronoun_replace(working_doc, i)
 
     return original_document
+
 
 def noun_replace(original_document):
     '''Returns a list of documents. Noun chunks that meet the specified
@@ -108,7 +128,7 @@ def noun_replace(original_document):
     
     return noun_mod_docs
 
-def verb_replace(original_document):
+def verb_replace(original_document, i=0):
     '''Returns a document replacing verbs meeting specified criteria with the
     structure "will {lemmatized verb}"
     
@@ -116,53 +136,39 @@ def verb_replace(original_document):
     ----------
     original_document : str
         Document in which you would like to replace verbs
+    i : int
+        Counter set to 0. I should put it in the function instead. I'll do that
+        later because right now it's working, and changing that will probably
+        magically break it... haha (sort of)
     '''
-
     nlp_doc = nlp(original_document)
 
     verb_count = 0
     for token in nlp_doc:
         if token.pos_ in ['VERB', 'AUX']:
-            verb_count += 1
+            verb_count +=1
+    # print("vc:",verb_count)
+    # print("i:",i)
 
-    if verb_count == 0:
+    if i == verb_count:
         return original_document
-    
+
     for token in nlp_doc:
+        # print(token)
+        # print(spacy.explain(token.tag_), '\n')
         token_tag = spacy.explain(token.tag_)
 
-        # Creating bail out statements (fail conditions) 
+        if (token.pos_ in ['VERB', 'AUX']
+            and token_tag in ["verb, 3rd person singular present"
+                             ,"verb, non-3rd person singular present"]
+            and token.dep_ != 'advcl'):
+            # This will not work for adverbial clauses, so add that logic in later
+            # working_doc = original_document.replace(str(token),f"will {token.lemma_}")
+            working_doc = re.sub(r'\b' + str(token) + r'\b', f"will {token.lemma_}", original_document)
+            # print("Working Doc:",working_doc)
+            i+=1
+            return verb_replace(working_doc, i)
 
-        # If the token in question isn't a verb or auxiliary verb
-        # continue on to the next token in the document
-        if token.pos_ not in ['VERB', 'AUX']:
-            continue
-        
-        # If the token tag isn't a 3rd person singular present tense verb
-        # or non-3rd person singular present tense verb, continue onward.
-        if token_tag not in ["verb, 3rd person singular present"
-                             , "verb, non-3rd person singular present"]:
-            # print(f"Not a verb in 3P: Token =  \'{token}\'")
-            continue
-
-        # If the token dependency is an adverbial clause, we want to bail 
-        # out early for now as this will not work for adverbial clauses; 
-        # logic will be added in later
-        if token.dep_ == 'advcl':
-            continue
-
-        # Now that the fail conditions are checked, 
-        # we can directly use the original logic.
-        # This logic will loop through the tokens in order
-        # meaning we no longer need to increment i. 
-        working_doc = original_document.replace(str(token),
-                                                f"will {token.lemma_}")
-                
-        # Only return if replacements have been made
-        if len(working_doc) > 0:
-            return working_doc
-
-    # Return the original if no replacements have been made.
     return original_document
 
 def verb_replace_advcl(original_document):
@@ -227,27 +233,39 @@ if __name__ == "__main__":
     for k in movie_data:
         plot = movie_data[k]['plot']
     # for plot in test_cases.EXAMPLE_SENTENCES:
-        pronouns_replaced = pronoun_replace(plot)
-        nouns_replaced = noun_replace(pronouns_replaced)
+        unique_pronoun_types = count_pronoun_types(plot)
+        if unique_pronoun_types <= 1:
+            pronouns_replaced = pronoun_replace(plot)
+            nouns_replaced = noun_replace(pronouns_replaced)
 
-        current_plot_outputs = []
-        for noun_plots in nouns_replaced:
-            verbs_replaced = verb_replace(noun_plots)
-            verbs_replaced = verb_replace_advcl(verbs_replaced)
-            current_plot_outputs.append(verbs_replaced)
+            current_plot_outputs = []
+            for noun_plots in nouns_replaced:
+                verbs_replaced = verb_replace(noun_plots)
+                verbs_replaced = verb_replace_advcl(verbs_replaced)
+                current_plot_outputs.append(verbs_replaced)
+                print(verbs_replaced,"\n----------")
 
-        all_outputs.append(current_plot_outputs)
+            all_outputs.append(current_plot_outputs)
 
-    # tool.close()
-
-
-    for i in all_outputs:
-        for j in i:
-            print(j,"\n----------")
-
-
+    # for i in all_outputs:
+    #     for j in i:
+    #         print(j,"\n----------")
 
 
+# plot = 'Gru meets his long-lost, charming, cheerful, and more successful twin brother Dru, who wants to team up with him for one last criminal heist.'
+
+# unique_pronoun_types = count_pronoun_types(plot)
+# if unique_pronoun_types <= 1:
+#     pronouns_replaced = pronoun_replace(plot)
+# nouns_replaced = noun_replace(pronouns_replaced)
+
+
+# # current_plot_outputs = []
+# for noun_plots in nouns_replaced:
+#     verbs_replaced = verb_replace(noun_plots)
+#     verbs_replaced = verb_replace_advcl(verbs_replaced)
+#     print(verbs_replaced)
+#     # current_plot_outputs.append(verbs_replaced)
 
         
 
@@ -255,7 +273,7 @@ if __name__ == "__main__":
 
 
 
-# for token in nlp(all_outputs[2][0]):
+# for token in nlp(plot):
 #      print (token, token.lemma_, token.dep_, token.tag_, token.pos_
 #             , spacy.explain(token.tag_), token.head)
 

--- a/fcm_dashApp/fcm_code/fortune_cookie.py
+++ b/fcm_dashApp/fcm_code/fortune_cookie.py
@@ -36,6 +36,8 @@ def count_pronoun_types(original_document):
 
     for token in nlp(nlp_doc):
         if token.pos_ == "PRON":
+            # this structure is great for possible debugging, but the below code block could be shortened to:
+            # pronoun_types_present.extend(key for key, val in pronouns_dict.items() if str(token) in val)
             # print(token)
             for key, val in pronouns_dict.items():
                 # print(key)
@@ -67,6 +69,8 @@ def pronoun_replace(original_document, i=0):
 
     nlp_doc = nlp(original_document)
 
+    # more concise, but possibly less readable depending on the reader's python experience:
+    # pronoun_count = sum(spacy.explain(token.tag_) in ["pronoun, possessive", "pronoun, personal"] for token in nlp_doc)
     pronoun_count = 0
     for token in nlp_doc:
         if spacy.explain(token.tag_) in ["pronoun, possessive", "pronoun, personal"]:
@@ -143,6 +147,8 @@ def verb_replace(original_document, i=0):
     """
     nlp_doc = nlp(original_document)
 
+    # same as above. more concise, but possibly less readable depending on the reader's python experience:
+    # verb_count = sum(token.pos_ in ['VERB', 'AUX'] for token in nlp_doc)
     verb_count = 0
     for token in nlp_doc:
         if token.pos_ in ['VERB', 'AUX']:
@@ -174,6 +180,8 @@ def verb_replace(original_document, i=0):
 def verb_replace_advcl(original_document):
     nlp_doc = nlp(original_document)
 
+    # same as above. more concise, but possibly less readable depending on the reader's python experience:
+    # verb_count = sum(token.pos_ in ['VERB', 'AUX'] for token in nlp_doc)
     verb_count = 0
     for token in nlp_doc:
         if token.pos_ in ['VERB', 'AUX']:

--- a/fcm_dashApp/fcm_code/fortune_cookie.py
+++ b/fcm_dashApp/fcm_code/fortune_cookie.py
@@ -82,14 +82,14 @@ def pronoun_replace(original_document, i=0):
         if (token_tag == "pronoun, possessive"
             and str(token) != "your"):
             working_doc = re.sub(r'\b' + str(token) + r'\b', "your", original_document)
-            i+=1
+            i += 1
             return pronoun_replace(working_doc, i)
         
         if (token_tag == "pronoun, personal"
             and str(token) != "yourself"):
             # working_doc = original_document.replace(str(token), "yourself")
             working_doc = re.sub(r'\b' + str(token) + r'\b', "you", original_document)
-            i+=1
+            i += 1
             return pronoun_replace(working_doc, i)
 
     return original_document
@@ -166,7 +166,7 @@ def verb_replace(original_document, i=0):
             # working_doc = original_document.replace(str(token),f"will {token.lemma_}")
             working_doc = re.sub(r'\b' + str(token) + r'\b', f"will {token.lemma_}", original_document)
             # print("Working Doc:",working_doc)
-            i+=1
+            i += 1
             return verb_replace(working_doc, i)
 
     return original_document

--- a/fcm_dashApp/pages/quiz.py
+++ b/fcm_dashApp/pages/quiz.py
@@ -1,4 +1,5 @@
 from base_app import app
+import random
 
 try:
     from dash import dcc
@@ -127,6 +128,7 @@ def update_clicker_output(n_clicks_click):
 
         # get list of 5 random films for the quiz options
         quiz_choices = [film]
+        # quiz_choices = random.shuffle(quiz_choices)
 
         for i in range(len(films)):
             sel = films[random.randint(0, len(films) -1)]

--- a/fcm_dashApp/pages/quiz.py
+++ b/fcm_dashApp/pages/quiz.py
@@ -100,7 +100,7 @@ def update_clicker_output(n_clicks_click):
         print("There are this many examples to choose from:")
         print(len(films))
 
-        film = films[random.randint(0, len(films) -1)]
+        film = films[random.randint(0, len(films) - 1)]
 
         plot = test_cases[film]["originalText"]
         pronouns_replaced = fc.pronoun_replace(plot)
@@ -115,7 +115,7 @@ def update_clicker_output(n_clicks_click):
         print(len(current_plot_outputs))
 
         if len(current_plot_outputs) > 1:
-            output = current_plot_outputs[random.randint(0, len(current_plot_outputs) -1)]
+            output = current_plot_outputs[random.randint(0, len(current_plot_outputs) - 1)]
         else:
             output = current_plot_outputs[0]
 

--- a/fcm_dashApp/pages/quiz.py
+++ b/fcm_dashApp/pages/quiz.py
@@ -132,9 +132,7 @@ def update_clicker_output(n_clicks_click):
 
         for _ in range(len(films)):
             sel = films[random.randint(0, len(films) -1)]
-            if sel in quiz_choices:
-                pass 
-            else: 
+            if sel not in quiz_choices:
                 quiz_choices.append(sel)
             if len(quiz_choices) == 4:
                 break

--- a/fcm_dashApp/pages/quiz.py
+++ b/fcm_dashApp/pages/quiz.py
@@ -130,7 +130,7 @@ def update_clicker_output(n_clicks_click):
         quiz_choices = [film]
         # quiz_choices = random.shuffle(quiz_choices)
 
-        for i in range(len(films)):
+        for _ in range(len(films)):
             sel = films[random.randint(0, len(films) -1)]
             if sel in quiz_choices:
                 pass 

--- a/fcm_dashApp/pages/quiz.py
+++ b/fcm_dashApp/pages/quiz.py
@@ -120,11 +120,11 @@ def update_clicker_output(n_clicks_click):
             output = current_plot_outputs[0]
 
         if n_clicks_click < 50:
-            counter = 'By the way, you have now clicked me {} times.'.format(n_clicks_click)
+            counter = f"By the way, you have now clicked me {n_clicks_click} times."
         elif 49 < n_clicks_click < 100:
-            counter = "By the way, you have now clicked me {} times. Easy there!".format(n_clicks_click),              
+            counter = f"By the way, you have now clicked me {n_clicks_click} times. Easy there!"
         else:
-            counter = "By the way, you have now clicked me {} times. It may be time for you to move on, friend".format(n_clicks_click),
+            counter = f"By the way, you have now clicked me {n_clicks_click} times. It may be time for you to move on, friend"
 
         # get list of 5 random films for the quiz options
         quiz_choices = [film]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ dash-core-components==2.0.0
 dash-html-components==2.0.0
 dash-table==5.0.0
 en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.4.0/en_core_web_sm-3.4.0-py3-none-any.whl
+en-core-web-trf @ https://github.com/explosion/spacy-models/releases/download/en_core_web_trf-3.1.0/en_core_web_trf-3.1.0-py3-none-any.whl
 fonttools==4.33.3
 langcodes==3.3.0
 language-tool-python==2.7.1


### PR DESCRIPTION
- Reformatted some of the strings to f-strings from using `format()`
- Added spacing for readability
- Changed docstrings from single quote to double quotes per [pep 257](http://www.python.org/dev/peps/pep-0257/)
- Updated some of the unused index variables from `i` to `_`
- Removed unnecessary `if` check
- Updated return statement to directly return the result instead of creating a variable and then immediately returning that variable
- Added comments suggesting possible refactors
  - Made these as comments instead of just changing them since there's a bit of a tradeoff between efficiency and readability
- Made file paths OS agnostic
- Updated `README.md` with instructions on how to run the web app and possible errors that users may encounter