### PR TITLE
Expose Docker port, add compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,42 @@ This repo is a project currently in progress to create some sort of application 
 Thanks for visiting!
 
 ## Running the web app
-Make sure you're in `fcm_dashApp/` and run `python fcm_app.py`
+
+There are a few ways to run this app, all shown below. Once you run one of the commands below the app should be available at [http://localhost:8050](http://localhost:8050).
+
+### With Docker Compose
+
+Getting started with Docker Compose is probably the easiest, assuming you have Docker and Docker Compose installed already. If you do then just run the below:
+
+```
+docker-compose up -d
+```
+
+The image should be automatically built as part of the above command. To build the image without starting the service you can run the following:
+
+```
+docker-compose build
+```
+
+To stop the docker-compose application run the below:
+
+```
+docker-compose down
+```
+
+### With Docker
+
+If you have Docker installed, but not Docker Compose, that's okay. First we need to build the image:
+
+```
+docker build --tag fcm-app .
+```
+
+Once the image is built you can run the app with the below Docker command:
+
+```
+docker run -p 8050:8050 fcm-app
+```
 
 #### Possible errors
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.0"
+services:
+  app:
+    build:
+      context: .
+    ports:
+      - "8050:8050"

--- a/dockerfile
+++ b/dockerfile
@@ -6,5 +6,7 @@ WORKDIR "/app"
 
 RUN pip3 install -r /tmp/requirements.txt
 
+EXPOSE 8050
+
 ENTRYPOINT [ "python3" ]
 CMD [ "fcm_app.py" ]


### PR DESCRIPTION
Hey @EricPostMaster, I added a command in the Dockerfile to `expose 8050` ([docs](https://docs.docker.com/engine/reference/builder/#expose)) which is where the app was running. I also added a docker-compose.yml file, which I find easier to work with when running an app.

The `expose 8050` in the Dockerfile tells Docker there is something listening on that port and that it can be exposed. Then either in the compose file or in your docker command you have to tell Docker to expose it to your local network.

Hope this helps and gets you running.